### PR TITLE
Fix for a re-initialization issue on surface destruction.

### DIFF
--- a/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
@@ -96,6 +96,8 @@ class TextureViewImpl extends TextureView implements
 
     @Override
     public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
+        LOG.trace("onSurfaceTextureDestroyed");
+        removeVideo();
         return false;
     }
 
@@ -125,8 +127,7 @@ class TextureViewImpl extends TextureView implements
 
     @Override
     public void onPause() {
-        placeholderView.setVisibility(View.VISIBLE);
-        release();
+        removeVideo();
     }
 
     private void release() {
@@ -137,6 +138,11 @@ class TextureViewImpl extends TextureView implements
         mediaPlayer = null;
         prepared = false;
         startInPrepare = false;
+    }
+
+    private void removeVideo(){
+        placeholderView.setVisibility(View.VISIBLE);
+        release();
     }
 
     @Override


### PR DESCRIPTION
A re-initialization issue on surface destruction fixed. For example when placing the video into the RecyclerView. The recycling of the view can be handled with #onResume()/#onPause() with the RecycleView#onBindViewHolder(...)/#onViewRecycled(...) callbacks. However the surface state change callbacks of the implementation are not accessible from the outside. The exact moment the texture view goes out of view (the last pixel scrolls out of the screen), TextureViewImpl#onSurfaceTextureDestroyed(Surface) gets called and the following onSurfaceTextureAvailable(Surface) doesn't initialize the media player due to not being released (and flag set).

The player should be properly released and the placeholder view shown on surface destruction now.