### PR TITLE
Mediaplayer prepare failure handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0-alpha4'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'  
+apply plugin: 'com.github.dcendents.android-maven'
 
 group='com.github.mklimek'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 10

--- a/library/src/main/java/com/mklimek/frameviedoview/FrameVideoViewListener.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/FrameVideoViewListener.java
@@ -3,8 +3,7 @@ package com.mklimek.frameviedoview;
 import android.media.MediaPlayer;
 
 public interface FrameVideoViewListener {
+    void mediaPlayerPrepared( MediaPlayer mediaPlayer );
 
-  void mediaPlayerPrepared( MediaPlayer mediaPlayer );
-
-  void mediaPlayerPrepareFailed( MediaPlayer mediaPlayer, String error );
+    void mediaPlayerPrepareFailed( MediaPlayer mediaPlayer, String error );
 }

--- a/library/src/main/java/com/mklimek/frameviedoview/FrameVideoViewListener.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/FrameVideoViewListener.java
@@ -3,5 +3,8 @@ package com.mklimek.frameviedoview;
 import android.media.MediaPlayer;
 
 public interface FrameVideoViewListener {
-    void mediaPlayerPrepared(MediaPlayer mediaPlayer);
+
+  void mediaPlayerPrepared( MediaPlayer mediaPlayer );
+
+  void mediaPlayerPrepareFailed( MediaPlayer mediaPlayer, String error );
 }

--- a/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
@@ -87,8 +87,8 @@ class TextureViewImpl extends TextureView implements
         } catch (Exception e) {
             if ( listener != null ) {
                 listener.mediaPlayerPrepareFailed( mediaPlayer, e.toString() );
-                removeVideo();
             }
+            removeVideo();
         }
     }
 

--- a/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
+++ b/library/src/main/java/com/mklimek/frameviedoview/TextureViewImpl.java
@@ -85,7 +85,10 @@ class TextureViewImpl extends TextureView implements
             mediaPlayer.setOnBufferingUpdateListener(this);
             mediaPlayer.prepare();
         } catch (Exception e) {
-            LOG.error("cannot prepare media player with SurfaceTexture", e);
+            if ( listener != null ) {
+                listener.mediaPlayerPrepareFailed( mediaPlayer, e.toString() );
+                removeVideo();
+            }
         }
     }
 


### PR DESCRIPTION
Added a callback for media player preparation failure. This takes care of the case where the device is unable to play the file due to unsupported codec (some older KitKat devices). For some devices the player is prepared and finished instantly, but for some it fails to prepare and gets stuck on a black view.

Also updated gradle/build tools.

This is the API breaking change. Should be probably updated to 1.3.0.
One note regarding the versioning. I have noticed you had moved from the gradle versioning to tagging release revisions only. Unfortunately to deploy the library to my local repo i have to add
```gradle
archivesBaseName = "frame-video-view"
version = "1.3.0"
```
to gradle script to be installed with a correct module name (instead of *:library*) and version. Do you use any other approach for local deployment?